### PR TITLE
sdm845-common: Restart audio HIDL HAL after decryption

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -59,3 +59,6 @@ on property:sys.boot_completed=1
     write /sys/block/dm-1/queue/read_ahead_kb 128
     write /sys/block/dm-2/queue/read_ahead_kb 128
     write /sys/block/dm-3/queue/read_ahead_kb 128
+
+on property:vold.decrypt=trigger_restart_framework
+    restart vendor.audio-hal-2-0


### PR DESCRIPTION
* For some reason, booting with headphones plugged in results
  in a broken speaker output if FDE secure boot is enabled.
* Restarting audio HAL after decryption seems to resolve the issue.

Change-Id: Ie14b89841bf811f0fb09edb0a04fd28aafecde87